### PR TITLE
Fix #10: rustfmt now uses the correct rustfmt.toml

### DIFF
--- a/commands/rustfmt.py
+++ b/commands/rustfmt.py
@@ -59,6 +59,7 @@ class AnacondaRustFmt(sublime_plugin.TextCommand):
                 'vid': self.view.id(),
                 'filename': path,
                 'settings': {'rustfmt_binary_path': rustfmt},
+                'wd': self.view.file_name(),
                 'method': 'format',
                 'handler': 'rustfmt'
             }

--- a/plugin/handlers_rust/commands/rustfmt.py
+++ b/plugin/handlers_rust/commands/rustfmt.py
@@ -24,6 +24,7 @@ class RustFMT(Command):
         self.vid = vid
         self.filename = filename
         self.settings = settings
+        self.wd = wd
         super(RustFMT, self).__init__(callback, uid)
 
     def run(self):
@@ -54,9 +55,19 @@ class RustFMT(Command):
         """Run the rustfmt command in a file
         """
 
-        args = shlex.split('{0} --write-mode=display {1}'.format(
-            self.settings.get('rustfmt_binary_path', 'rustfmt'), self.filename
-        ), posix=os.name != 'nt')
+        if self.wd is not None:
+            wd = os.path.dirname(self.wd)
+        else:
+            wd = os.getcwd()
+
+        args = shlex.split(
+            '{0} --write-mode=display --config-path {1} {2}'.format(
+                self.settings.get('rustfmt_binary_path', 'rustfmt'),
+                wd,
+                self.filename
+            ),
+            posix=os.name != 'nt')
+
         proc = spawn(args, stdout=PIPE, stderr=PIPE, cwd=os.getcwd())
         output, err = proc.communicate()
         if sys.version_info >= (3, 0):
@@ -71,4 +82,4 @@ class RustFMT(Command):
             self.error = err
             raise Exception(err)
 
-        return '\n'.join(output.splitlines()[2:])
+        return '\n'.join(output.splitlines()[3:])

--- a/plugin/handlers_rust/rust_fmt_handler.py
+++ b/plugin/handlers_rust/rust_fmt_handler.py
@@ -13,8 +13,8 @@ class RustFMTHandler(anaconda_handler.AnacondaHandler):
 
     __handler_type__ = 'rustfmt'
 
-    def format(self, filename=None, settings=None):
+    def format(self, filename=None, settings=None, wd=None):
         """Run the rustfmt in a file
         """
 
-        RustFMT(self.callback, self.uid, self.vid, filename, settings)
+        RustFMT(self.callback, self.uid, self.vid, filename, settings, wd)


### PR DESCRIPTION
This is my attempt to fix #10 ... as I already mentioned in the issue I don't know anything about python and sublime plugin development. This solution works for me, but someone should do some proper code review ^_^
