### PR TITLE
UTF-8 encode non-ASCII code in rustfmt command.

### DIFF
--- a/commands/rustfmt.py
+++ b/commands/rustfmt.py
@@ -53,7 +53,7 @@ class AnacondaRustFmt(sublime_plugin.TextCommand):
 
             # the JonServer deletes the temp file so we don't worry
             fd, path = tempfile.mkstemp(suffix=".rs", dir=file_directory())
-            with os.fdopen(fd, "w") as tmp:
+            with os.fdopen(fd, "w", encoding="utf-8") as tmp:
                 tmp.write(self.code)
 
             config_path = get_settings(self.view, 'rust_rustfmt_config_path')


### PR DESCRIPTION
Running the format command on files containing non-ASCII text currently breaks with the following error:

    ERROR:root:Traceback (most recent call last):
      File "/Users/mischu/Library/Application Support/Sublime Text 3/Packages/anaconda_rust/commands/rustfmt.py", line 57, in run
        tmp.write(self.code)
    UnicodeEncodeError: 'ascii' codec can't encode character '\xf2' in position 30: ordinal not in range(128)

This can be reproduced by the following code-snippet:

    fn main() { println!("ò"); }

This pull-request fixes this by specifying UTF-8 encoding for the temporary file.